### PR TITLE
Fix version json file path

### DIFF
--- a/src/version/program-calc-next-version.ts
+++ b/src/version/program-calc-next-version.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { VERSION_FILE } from '../constants'
 
 const calculateNewVersion = () => {
-  const versionFile = fs.readFileSync(path.resolve(__dirname, '..', VERSION_FILE), 'utf-8') // FIXME path wrong
+  const versionFile = fs.readFileSync(VERSION_FILE, 'utf-8')
   // versionCode is just used in the integreat-react-native-app
   const { versionName, versionCode } = JSON.parse(versionFile)
   const versionNameParts = versionName.split('.').map((it: string) => parseInt(it, 10))


### PR DESCRIPTION
Now version.json will be called from current directory and no longer from source directory, which is inside global node_modules folder.