### PR TITLE
github-assets-promote

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,11 @@
-export type Platform = 'ios' | 'android' | 'web'
+export type Platform = 'ios' | 'android' | 'web' | 'all'
 
 export const PLATFORM_ANDROID: Platform = 'android'
 export const PLATFORM_IOS: Platform = 'ios'
 export const PLATFORM_WEB: Platform = 'web'
-export const PLATFORMS: Platform[] = [PLATFORM_ANDROID, PLATFORM_IOS, PLATFORM_WEB]
+
+export const PLATTFORM_ALL: Platform = 'all'
+export const PLATFORMS: Platform[] = [PLATFORM_ANDROID, PLATFORM_IOS, PLATFORM_WEB, PLATTFORM_ALL]
 
 export const VERSION_FILE = 'version.json'
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -9,6 +9,8 @@ import writeXcConfig from './build-config/program-write-xcconfig'
 import calcNextVersion from './version/program-calc-next-version'
 import gitRelease from './release/program-git-release'
 import githubRelease from './release/program-github-release'
+import githubReleaseAssets from './release/program-github-release-assets'
+import githubPromoteRelease from './release/program-github-promote-release'
 import jiraRelease from './release/program-jira-release'
 import sentryRelease from './release/program-sentry-release'
 import triggerPipeline from './ci/program-trigger-pipeline'
@@ -40,6 +42,8 @@ const buildCommand = (exitOverride?: (err: CommanderError) => never | void) => {
   const releaseCommand = v0.command('release')
   gitRelease(releaseCommand)
   githubRelease(releaseCommand)
+  githubReleaseAssets(releaseCommand)
+  githubPromoteRelease(releaseCommand)
   jiraRelease(releaseCommand)
   sentryRelease(releaseCommand)
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -133,7 +133,7 @@ export const createGithubRelease = async (
   appOctokit: Octokit,
   owner: string,
   repo: string,
-  prerelease: boolean,
+  productionRelease: boolean,
   shouldUsePredefinedReleaseNotes: boolean,
   predefinedReleaseNotes?: string
 ) => {
@@ -141,13 +141,14 @@ export const createGithubRelease = async (
   const tagName = versionTagName({ versionName: newVersionName, platform })
 
 
-  await appOctokit.repos.createRelease({
+  const release = await appOctokit.repos.createRelease({
     owner,
     repo,
     tag_name: tagName,
-    prerelease,
+    prerelease: !productionRelease,
     make_latest: platform === 'android' ? 'true' : 'false',
     name: releaseName,
     body: shouldUsePredefinedReleaseNotes && predefinedReleaseNotes ? predefinedReleaseNotes : (await generateReleaseNotesFromGithubEndpoint(owner, repo, appOctokit, tagName))
   })
+  console.log(release.data.id)
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app'
 import { Octokit } from '@octokit/rest'
-import { MAIN_BRANCH, Platform, PLATFORMS, VERSION_FILE } from './constants'
+import { Platform, PLATFORMS, VERSION_FILE } from './constants'
 
 export const authenticate = async ({
   deliverinoPrivateKey,
@@ -106,41 +106,48 @@ export const createTags = async (
   )
 }
 
+const generateReleaseNotes = async (
+  owner: string,
+  repo: string,
+  appOctokit: Octokit,
+  tagName: string
+): Promise<string> => {
+  try {
+    const response = await appOctokit.request(`POST /repos/${owner}/${repo}/releases/generate-notes`, {
+      owner,
+      repo,
+      tag_name: tagName,
+      target_commitish: 'main',
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    })
+    return response.data.body
+  } catch (e) {
+    throw new Error("Couldn't get release notes")
+  }
+}
+
 export const createGithubRelease = async (
   platform: Platform,
   newVersionName: string,
   newVersionCode: number,
   owner: string,
   repo: string,
-  releaseNotes: string,
-  downloadLinks: string,
-  developmentRelease: boolean,
-  dryRun: boolean,
-  appOctokit: Octokit
+  prerelease: string,
+  appOctokit: Octokit,
+  predefinedReleaseNotes?: string
 ) => {
-  const releaseName = `[${platform}${
-    developmentRelease ? ' development release' : ''
-  }] ${newVersionName} - ${newVersionCode}`
-  console.warn('Creating release with name ', releaseName)
-
-  const developmentMessage = developmentRelease
-    ? 'This release is only delivered to development and not yet visible for users.\n\n'
-    : ''
-
-  const body = `${developmentMessage}${JSON.parse(releaseNotes)}${
-    downloadLinks ? `\nArtifacts:\n${downloadLinks}` : ''
-  }`
-  console.warn('and body ', body)
-
-  if (dryRun) {
-    return
-  }
+  const releaseName = `[${platform}] ${newVersionName} - ${newVersionCode}`
+  const tagName = versionTagName({ versionName: newVersionName, platform })
 
   await appOctokit.repos.createRelease({
     owner,
     repo,
-    tag_name: versionTagName({ versionName: newVersionName, platform }),
+    tag_name: tagName,
+    prerelease: prerelease === 'true',
+    make_latest: platform === 'android' ? 'true' : 'false',
     name: releaseName,
-    body
+    body: predefinedReleaseNotes ?? (await generateReleaseNotes(owner, repo, appOctokit, tagName))
   })
 }

--- a/src/release/program-github-promote-release.ts
+++ b/src/release/program-github-promote-release.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest'
 import { GetResponseTypeFromEndpointMethod } from '@octokit/types'
-import { program } from 'commander'
+import {Command} from 'commander'
 import { authenticate } from '../github'
 
 const octokit = new Octokit()
@@ -46,7 +46,8 @@ const removePreRelease = async ({ deliverinoPrivateKey, owner, repo, platform }:
   }
 }
 
-program
+export default (parent: Command) =>
+ parent
   .command('promote')
   .description('Remove pre-release flag from the latest release')
   .requiredOption(
@@ -64,5 +65,3 @@ program
       process.exit(1)
     }
   })
-
-program.parse(process.argv)

--- a/src/release/program-github-promote-release.ts
+++ b/src/release/program-github-promote-release.ts
@@ -1,0 +1,68 @@
+import { Octokit } from '@octokit/rest'
+import { GetResponseTypeFromEndpointMethod } from '@octokit/types'
+import { program } from 'commander'
+import { authenticate } from '../github'
+
+const octokit = new Octokit()
+type Releases = GetResponseTypeFromEndpointMethod<typeof octokit.repos.listReleases>
+
+type Options = {
+  deliverinoPrivateKey: string
+  owner: string
+  repo: string
+  platform: 'web' | 'android' | 'ios'
+}
+
+const getReleaseId = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
+  const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
+
+  const releases: Releases = await appOctokit.rest.repos.listReleases({
+    owner,
+    repo
+  })
+
+  const result = releases.data.find(release => release.tag_name.includes(platform))
+  if (result && result.prerelease) {
+    console.log('Unset prerelease tag of ', result.tag_name)
+    return result.id
+  }
+
+  console.log('No release found to unset the prerelease tag for. Latest release may already be non-prerelease')
+  return null
+}
+
+const removePreRelease = async ({ deliverinoPrivateKey, owner, repo, platform }: Options) => {
+  const releaseId = await getReleaseId({ deliverinoPrivateKey, owner, repo, platform })
+  if (releaseId) {
+    const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
+    const result = await appOctokit.rest.repos.updateRelease({
+      owner,
+      repo,
+      release_id: releaseId,
+      prerelease: false,
+      make_latest: platform === 'android' ? 'true' : 'false' // We always want android to be the latest release, so a link to the latest github release will go to the apk
+    })
+    console.log('Http response code of updating the result: ', result.status)
+  }
+}
+
+program
+  .command('promote')
+  .description('Remove pre-release flag from the latest release')
+  .requiredOption(
+    '--deliverino-private-key <deliverino-private-key>',
+    'private key of the deliverino github app in pem format with base64 encoding'
+  )
+  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
+  .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
+  .requiredOption('--platform <platform>')
+  .action(async (options: Options) => {
+    try {
+      await removePreRelease(options)
+    } catch (e) {
+      console.error(e)
+      process.exit(1)
+    }
+  })
+
+program.parse(process.argv)

--- a/src/release/program-github-release-assets.ts
+++ b/src/release/program-github-release-assets.ts
@@ -1,4 +1,4 @@
-import { program } from 'commander'
+import {Command} from 'commander'
 import fs from 'node:fs'
 import { authenticate } from '../github'
 
@@ -30,7 +30,8 @@ const uploadAssets = async ({ deliverinoPrivateKey, owner, repo, releaseId, file
       })
 }
 
-program
+export default (parent: Command) =>
+ parent
   .command('upload')
   .description('Upload a release asset to github')
   .requiredOption(
@@ -49,5 +50,3 @@ program
       process.exit(1)
     }
   })
-
-program.parse(process.argv)

--- a/src/release/program-github-release-assets.ts
+++ b/src/release/program-github-release-assets.ts
@@ -1,0 +1,50 @@
+import { program } from 'commander'
+import fs from 'node:fs'
+import { authenticate } from '../github'
+
+type Options = {
+  deliverinoPrivateKey: string
+  owner: string
+  repo: string
+  releaseId: number
+  files: string
+}
+
+const uploadAssets = async ({ deliverinoPrivateKey, owner, repo, releaseId, files }: Options) => {
+  const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
+
+  for (const file of files.split('\n')) {
+    console.log(`Uploading ${file}`)
+    const filename = file.substring(file.lastIndexOf('/') + 1)
+    const fileData = fs.readFileSync(file)
+    await appOctokit.rest.repos.uploadReleaseAsset({
+      owner,
+      repo,
+      release_id: releaseId,
+      name: filename,
+      data: fileData as unknown as string
+    })
+  }
+}
+
+program
+  .command('upload')
+  .description('Upload a release asset to github')
+  .requiredOption(
+    '--deliverino-private-key <deliverino-private-key>',
+    'private key of the deliverino github app in pem format with base64 encoding'
+  )
+  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
+  .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
+  .requiredOption('--releaseId <releaseId>', 'The unique identifier of the release.')
+  .requiredOption('--files <files>', 'The name of the files to upload.')
+  .action(async (options: Options) => {
+    try {
+      await uploadAssets(options)
+    } catch (e) {
+      console.error(e)
+      process.exit(1)
+    }
+  })
+
+program.parse(process.argv)

--- a/src/release/program-github-release-assets.ts
+++ b/src/release/program-github-release-assets.ts
@@ -13,18 +13,21 @@ type Options = {
 const uploadAssets = async ({ deliverinoPrivateKey, owner, repo, releaseId, files }: Options) => {
   const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
 
-  for (const file of files.split('\n')) {
-    console.log(`Uploading ${file}`)
-    const filename = file.substring(file.lastIndexOf('/') + 1)
-    const fileData = fs.readFileSync(file)
-    await appOctokit.rest.repos.uploadReleaseAsset({
-      owner,
-      repo,
-      release_id: releaseId,
-      name: filename,
-      data: fileData as unknown as string
-    })
-  }
+  files
+      .split('\n')
+      .filter(file => !file.includes('e2e'))
+      .forEach(async file => {
+        console.log(`Uploading ${file}`)
+        const filename = file.substring(file.lastIndexOf('/') + 1)
+        const fileData = fs.readFileSync(file)
+        await appOctokit.rest.repos.uploadReleaseAsset({
+          owner,
+          repo,
+          release_id: releaseId,
+          name: filename,
+          data: fileData as unknown as string,
+        })
+      })
 }
 
 program

--- a/src/release/program-github-release.ts
+++ b/src/release/program-github-release.ts
@@ -10,7 +10,7 @@ export default (parent: Command) =>
     )
     .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
     .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
-    .requiredOption('--prerelease <prerelease>', 'whether this is a prerelease (beta) or not')
+    .requiredOption('--production-release <production-release>', 'whether this is a production release or not')
     .requiredOption('--should-use-predefined-release-notes <should-use-predefined-release-notes>', 'whether predefined release notes should be used or not. Release notes have to be passed if true.')
     .option(
       '--release-notes <release-notes>',
@@ -37,7 +37,7 @@ export default (parent: Command) =>
           appOctokit,
           options.owner,
           options.repo,
-          options.prerelease === 'true',
+          options.productionRelease === 'true',
           options.shouldUsePredefinedReleaseNotes === 'true',
           options.releaseNotes
         )

--- a/src/release/program-github-release.ts
+++ b/src/release/program-github-release.ts
@@ -10,13 +10,11 @@ export default (parent: Command) =>
     )
     .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
     .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
-    .requiredOption('--release-notes <release-notes>', 'the release notes (for the selected platform) as JSON string')
-    .option('--download-links <download-links>', 'the download links of the artifacts (for the selected platform)')
+    .requiredOption('--prerelease <prerelease>', 'weather this is a prerelease (beta) or not')
     .option(
-      '--development-release',
-      'whether the release is a development release which is not delivered to production'
+      '--release-notes <release-notes>',
+      'the release notes (for the selected platform) as JSON string. If not defined the release notes will be generated'
     )
-    .option('--dry-run', 'dry run without actually creating a release on github')
     .description('creates a new release for the specified platform')
     .action(async (platform, newVersionName, newVersionCode, options: { [key: string]: any }) => {
       try {
@@ -37,11 +35,9 @@ export default (parent: Command) =>
           newVersionCode,
           options.owner,
           options.repo,
-          options.developmentRelease,
-          options.downloadLinks,
-          options.releaseNotes,
-          options.dryRun,
-          appOctokit
+          options.prerelease,
+          appOctokit,
+          options.releaseNotes
         )
       } catch (e) {
         console.error(e)

--- a/src/release/program-github-release.ts
+++ b/src/release/program-github-release.ts
@@ -10,7 +10,8 @@ export default (parent: Command) =>
     )
     .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
     .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
-    .requiredOption('--prerelease <prerelease>', 'weather this is a prerelease (beta) or not')
+    .requiredOption('--prerelease <prerelease>', 'whether this is a prerelease (beta) or not')
+    .requiredOption('--should-use-predefined-release-notes <should-use-predefined-release-notes>', 'whether predefined release notes should be used or not. Release notes have to be passed if true.')
     .option(
       '--release-notes <release-notes>',
       'the release notes (for the selected platform) as JSON string. If not defined the release notes will be generated'
@@ -33,10 +34,11 @@ export default (parent: Command) =>
           platform,
           newVersionName,
           newVersionCode,
+          appOctokit,
           options.owner,
           options.repo,
-          options.prerelease,
-          appOctokit,
+          options.prerelease === 'true',
+          options.shouldUsePredefinedReleaseNotes === 'true',
           options.releaseNotes
         )
       } catch (e) {

--- a/test/__snapshots__/v0.test.ts.snap
+++ b/test/__snapshots__/v0.test.ts.snap
@@ -49,6 +49,8 @@ Options:
 Commands:
   bump-to [options] <new-version-name> <new-version-code>                      commits the supplied version name and code to github and tags the commit
   create [options] <platform> <new-version-name> <new-version-code>            creates a new release for the specified platform
+  upload [options]                                                             Upload a release asset to github
+  promote [options]                                                            Remove pre-release flag from the latest release
   jira-create [options] <new-version-name>                                     create a new release with the name <new-version-name> on jira and assign all issues resolved since the last release
   sentry-create [options] <package-name> <version-name> <sourcemap-directory>  create a new release on sentry. This file uses the configuration from ./.sentryclirc
   help [command]                                                               display help for command


### PR DESCRIPTION
- add function to add assets (mainly copied from integreat)
- add function promote github release (mainly copied from integreat)
- set release notes param to optional and generate release note from github if not provided

needed for https://github.com/digitalfabrik/entitlementcard/issues/1165)and https://github.com/digitalfabrik/entitlementcard/issues/1232