### PR TITLE
bump-up-add-platform-option

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,11 +1,12 @@
-export type Platform = 'ios' | 'android' | 'web' | 'all'
+export type Platform = 'ios' | 'android' | 'web' | 'all' | 'native'
 
 export const PLATFORM_ANDROID: Platform = 'android'
 export const PLATFORM_IOS: Platform = 'ios'
 export const PLATFORM_WEB: Platform = 'web'
+export const PLATFORM_NATIVE: Platform = 'native'
 
-export const PLATTFORM_ALL: Platform = 'all'
-export const PLATFORMS: Platform[] = [PLATFORM_ANDROID, PLATFORM_IOS, PLATFORM_WEB, PLATTFORM_ALL]
+export const PLATFORM_ALL: Platform = 'all'
+export const PLATFORMS: Platform[] = [PLATFORM_ANDROID, PLATFORM_IOS, PLATFORM_WEB, PLATFORM_NATIVE, PLATFORM_ALL]
 
 export const VERSION_FILE = 'version.json'
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app'
 import { Octokit } from '@octokit/rest'
-import { Platform, PLATFORMS, VERSION_FILE } from './constants'
+import {Platform, PLATFORMS, VERSION_FILE} from './constants'
 
 export const authenticate = async ({
   deliverinoPrivateKey,
@@ -95,10 +95,12 @@ export const createTags = async (
   commitSha: string,
   owner: string,
   repo: string,
-  appOctokit: Octokit
+  appOctokit: Octokit,
+  predefinedPlatform?: Platform
 ) => {
+  const platforms = predefinedPlatform ? [predefinedPlatform] : PLATFORMS
   await Promise.all(
-    PLATFORMS.map(platform => {
+    platforms.map(platform => {
       const tagName = versionTagName({ versionName, platform })
       const tagMessage = `[${platform}] ${versionName} - ${versionCode}`
       return createTag(tagName, tagMessage, owner, repo, commitSha!, appOctokit)

--- a/src/release/program-git-release.ts
+++ b/src/release/program-git-release.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander'
 import { authenticate, commitVersion, createTags } from '../github'
+import { Platform, PLATFORMS } from '../constants'
+import { getPlatformsFromString } from '../util'
 
 export default (parent: Command) =>
   parent
@@ -11,7 +13,10 @@ export default (parent: Command) =>
     .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
     .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
     .requiredOption('--branch <branch>', 'the current branch')
-    .option('--platform <platform>', 'define a particular platform for the tag. If unset tags for all platforms will be created')
+    .option(
+      '--platforms <platforms>',
+      'define the platforms separated by slash for the tags f.e. "native/web". If unset tags for all platforms will be created'
+    )
     .description('commits the supplied version name and code to github and tags the commit')
     .action(async (newVersionName, newVersionCode, options: { [key: string]: any }) => {
       try {
@@ -39,7 +44,9 @@ export default (parent: Command) =>
           throw new Error(`Failed to commit!`)
         }
 
-        await createTags(newVersionName, versionCode, commitSha, options.owner, options.repo, appOctokit, options.platform)
+        const platforms = getPlatformsFromString(options.platforms)
+
+        await createTags(newVersionName, versionCode, commitSha, options.owner, options.repo, appOctokit, platforms)
       } catch (e) {
         console.error(e)
         process.exit(1)

--- a/src/release/program-git-release.ts
+++ b/src/release/program-git-release.ts
@@ -11,6 +11,7 @@ export default (parent: Command) =>
     .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
     .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
     .requiredOption('--branch <branch>', 'the current branch')
+    .option('--platform <platform>', 'define a particular platform for the tag. If unset tags for all platforms will be created')
     .description('commits the supplied version name and code to github and tags the commit')
     .action(async (newVersionName, newVersionCode, options: { [key: string]: any }) => {
       try {
@@ -38,7 +39,7 @@ export default (parent: Command) =>
           throw new Error(`Failed to commit!`)
         }
 
-        await createTags(newVersionName, versionCode, commitSha, options.owner, options.repo, appOctokit)
+        await createTags(newVersionName, versionCode, commitSha, options.owner, options.repo, appOctokit, options.platform)
       } catch (e) {
         console.error(e)
         process.exit(1)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,1 +1,19 @@
+import { Platform, PLATFORMS } from './constants'
+
 export const nonNullablePredicate = <T>(value: T): value is NonNullable<T> => value !== null && value !== undefined
+
+export const getPlatformsFromString = (platformsString?: string): Platform[] | undefined => {
+  if (!platformsString) {
+    return undefined
+  }
+  const delimiter = '/'
+  const platforms = platformsString.split(delimiter) as Platform[]
+  if (!platforms.every((platform: Platform) => PLATFORMS.includes(platform))) {
+    throw new Error(
+      `Provided platforms are incorrect! Please check available platforms (${PLATFORMS.join(
+        ','
+      )}) and correct delimiter (${delimiter})`
+    )
+  }
+  return platforms
+}


### PR DESCRIPTION
- add an optional parameter to pass one or multiple platforms that will be used for creating git tags
- add native platform
- create tags for all platforms if no platform was provided