### PR TITLE
Handle correctly if no assets are to be released

### DIFF
--- a/src/release/program-github-release-assets.ts
+++ b/src/release/program-github-release-assets.ts
@@ -1,4 +1,4 @@
-import {Command} from 'commander'
+import { Command } from 'commander'
 import fs from 'node:fs'
 import { authenticate } from '../github'
 
@@ -11,12 +11,18 @@ type Options = {
 }
 
 const uploadAssets = async ({ deliverinoPrivateKey, owner, repo, releaseId, files }: Options) => {
+  if (!files) {
+    console.log('No files to upload. Skipping.')
+    return
+  }
+
   const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
 
-  files
+  await Promise.all(
+    files
       .split('\n')
       .filter(file => !file.includes('e2e'))
-      .forEach(async file => {
+      .map(async file => {
         console.log(`Uploading ${file}`)
         const filename = file.substring(file.lastIndexOf('/') + 1)
         const fileData = fs.readFileSync(file)
@@ -25,28 +31,29 @@ const uploadAssets = async ({ deliverinoPrivateKey, owner, repo, releaseId, file
           repo,
           release_id: releaseId,
           name: filename,
-          data: fileData as unknown as string,
+          data: fileData as unknown as string
         })
       })
+  )
 }
 
 export default (parent: Command) =>
- parent
-  .command('upload')
-  .description('Upload a release asset to github')
-  .requiredOption(
-    '--deliverino-private-key <deliverino-private-key>',
-    'private key of the deliverino github app in pem format with base64 encoding'
-  )
-  .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
-  .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
-  .requiredOption('--releaseId <releaseId>', 'The unique identifier of the release.')
-  .requiredOption('--files <files>', 'The name of the files to upload.')
-  .action(async (options: Options) => {
-    try {
-      await uploadAssets(options)
-    } catch (e) {
-      console.error(e)
-      process.exit(1)
-    }
-  })
+  parent
+    .command('upload')
+    .description('Upload a release asset to github')
+    .requiredOption(
+      '--deliverino-private-key <deliverino-private-key>',
+      'private key of the deliverino github app in pem format with base64 encoding'
+    )
+    .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
+    .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
+    .requiredOption('--releaseId <releaseId>', 'The unique identifier of the release.')
+    .requiredOption('--files <files>', 'The name of the files to upload.')
+    .action(async (options: Options) => {
+      try {
+        await uploadAssets(options)
+      } catch (e) {
+        console.error(e)
+        process.exit(1)
+      }
+    })


### PR DESCRIPTION
If no assets are to be released and therefore `files === ''`, the github release assets commands fails as it tries to upload the file with the path `''`. Therefore gracefully return without doing anything if no assets are to be released.

Fixes: https://github.com/digitalfabrik/entitlementcard/issues/1521