### PR TITLE
29: Modify the app version for a release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-toolbelt",
-  "version": "0.0.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-toolbelt",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "dependencies": {
         "@octokit/auth-app": "^7.1.5",
         "@octokit/rest": "^21.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.4.0",
   "name": "app-toolbelt",
   "description": "Toolbelt for digitalfabrik apps",
   "private": true,

--- a/src/core.ts
+++ b/src/core.ts
@@ -14,9 +14,10 @@ import githubPromoteRelease from './release/program-github-promote-release.js'
 import sentryRelease from './release/program-sentry-release.js'
 import triggerPipeline from './ci/program-trigger-pipeline.js'
 import notify from './notify/notify.js'
+import packageJson from '../package.json' with { type: 'json' }
 
 const buildCommand = (exitOverride?: (err: CommanderError) => never | void) => {
-  let root = new Command().version('0.1.0').option('-d, --debug', 'enable extreme logging')
+  let root = new Command().version(packageJson.version).option('-d, --debug', 'enable extreme logging')
 
   if (exitOverride) {
     root.exitOverride(exitOverride)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "noUncheckedIndexedAccess": true,
     "strict": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "noUncheckedIndexedAccess": true,
     "strict": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   }
 }


### PR DESCRIPTION
- Changed the app version to 0.4.0
- The main command at `core.ts`  now uses the package.json version instead of hard-coding it.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #29 