### PR TITLE
19: Merging integreat-app tools into app-toolbelt

### DIFF
--- a/src/ci/program-trigger-pipeline.ts
+++ b/src/ci/program-trigger-pipeline.ts
@@ -10,13 +10,18 @@ const WORKFLOW_TYPES = [
   'native_production_delivery',
   'native_promotion',
   'web_production_delivery',
-  'delivery'
+  'delivery',
+  'promotion',
+  'native_beta_delivery',
+  'web_promotion',
+  'web_beta_delivery'
 ]
 
 export default (parent: Command) =>
   parent
     .command('trigger <workflow-type>')
     .requiredOption('--api-token <api-token>', 'circleci api token')
+    .option('--branch <branch>', 'the branch the workflow will be triggered on', MAIN_BRANCH)
     .description(`trigger a workflow in the ci on the main branch`)
     .action(async (workflowType: string, options: { [key: string]: any }) => {
       try {
@@ -25,7 +30,7 @@ export default (parent: Command) =>
         }
 
         const postData = {
-          branch: MAIN_BRANCH,
+          branch: options.branch,
           parameters: {
             api_triggered: true,
             workflow_type: workflowType

--- a/src/release-notes/program-move-to.ts
+++ b/src/release-notes/program-move-to.ts
@@ -104,7 +104,7 @@ export default (parent: Command) =>
       '--deliverino-private-key <deliverino-private-key>',
       'private key of the deliverino github app in pem format with base64 encoding'
     )
-    .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
+    .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
     .requiredOption('--repo <repo>', 'the current repository, usually "integreat-app"')
     .requiredOption('--branch <branch>', 'the current branch')
     .argument('new-version-name')

--- a/src/release-notes/program-parse-release-notes.ts
+++ b/src/release-notes/program-parse-release-notes.ts
@@ -65,7 +65,7 @@ const parseReleaseNotes = ({
   return formatDevelopmentNotes({ notes: relevantNotes, language, platforms })
 }
 
-const parseNotesProgram = (options: ParseProgramOptionsType) => {
+export const parseNotesProgram = (options: ParseProgramOptionsType) => {
   try {
     const notes = parseReleaseNotes({ ...options })
 

--- a/src/release-notes/program-prepare-metadata.ts
+++ b/src/release-notes/program-prepare-metadata.ts
@@ -3,6 +3,7 @@ import { StoreName } from './constants.js'
 import { languageMap, loadStoreTranslations, metadataFromTranslations } from './translation.js'
 import fs from 'fs'
 import { RELEASE_NOTES_DIR, UNRELEASED_DIR } from './constants.js'
+import { parseNotesProgram } from './program-parse-release-notes.js'
 
 const metadataPath = (appName: string, storeName: StoreName, languageCode: string) =>
   `../native/${storeName === 'appstore' ? 'ios' : 'android'}/fastlane/${appName}/metadata/${languageCode}`
@@ -37,7 +38,7 @@ const writeMetadata = (appName: string, storeName: string, overrideVersionName?:
       fs.mkdirSync(releaseNotesPath, { recursive: true })
 
       const destination = `${releaseNotesPath}/${storeName === 'appstore' ? 'release_notes.txt' : 'default.txt'}`
-      //parseNotesProgram({ ...platforms, production: true, language, destination, source, appName })
+      parseNotesProgram({ ...platforms, production: true, language, destination, source, appName })
 
       console.warn(`${storeName} metadata for ${appName} successfully written in language ${targetLanguage}.`)
     })

--- a/src/release/program-git-release.ts
+++ b/src/release/program-git-release.ts
@@ -10,7 +10,7 @@ export default (parent: Command) =>
       '--deliverino-private-key <deliverino-private-key>',
       'private key of the deliverino github app in pem format with base64 encoding'
     )
-    .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
+    .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
     .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
     .requiredOption('--branch <branch>', 'the current branch')
     .option(

--- a/src/release/program-github-release.ts
+++ b/src/release/program-github-release.ts
@@ -8,7 +8,7 @@ export default (parent: Command) =>
       '--deliverino-private-key <deliverino-private-key>',
       'private key of the deliverino github app in pem format with base64 encoding'
     )
-    .requiredOption('--owner <owner>', 'owner of the current repository, usually "Integreat"')
+    .requiredOption('--owner <owner>', 'owner of the current repository, usually "digitalfabrik"')
     .requiredOption('--repo <repo>', 'the current repository, should be integreat-app')
     .option('--production-release', 'whether this is a production release or not. If unset false')
     .option(


### PR DESCRIPTION
### Short Description
Merge changes on the scripts in this repository and changes in integreat-app/tools.


### Proposed Changes
- I checked all files in the tools folder at integreat-app and compared each command with what we have in app-toolbelt:
- `parseNotesProgram` was enabled at integreat so I uncommented that line.
- For `trigger` command I added branch option and included `WORKFLOW_TYPES` that are used in integreat-app.

### Side Effects

- None

### Testing

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #19