### PR TITLE
Fix versioning for integreat

### DIFF
--- a/src/build-config/loader.ts
+++ b/src/build-config/loader.ts
@@ -1,30 +1,11 @@
 import decamelize from 'decamelize'
 import { flatten } from 'flat'
 import { Platform, PLATFORMS } from '../constants.js'
-import path from 'path'
+import { findPathInParents } from '../util.js'
 
 export type BuildConfigPlatformType = Platform | 'common'
 const PLATFORM_COMMON: BuildConfigPlatformType = 'common'
 const BUILD_CONFIG_PLATFORMS: BuildConfigPlatformType[] = [...PLATFORMS, PLATFORM_COMMON]
-
-const findBuildConfigDirectoryInParent = async (
-  buildConfigName: string,
-  buildConfigDirectory: string
-): Promise<any | null> => {
-  let currentDirectory = process.cwd()
-
-  for (let i = 0; i < 8; i++) {
-    let buildConfigPath = `${currentDirectory}/${buildConfigDirectory}/${buildConfigName}`
-    try {
-      const module = await import(buildConfigPath)
-      return module.default
-    } catch (e) {
-      currentDirectory = path.resolve(currentDirectory, '..')
-    }
-  }
-
-  return null
-}
 
 export const loadBuildConfig = async (
   buildConfigName: string | null | undefined,
@@ -39,7 +20,7 @@ export const loadBuildConfig = async (
     throw Error(`Invalid platform supplied: ${platform}`)
   }
 
-  const buildConfig = await findBuildConfigDirectoryInParent(buildConfigName, buildConfigDirectory)
+  const buildConfig = (await import(findPathInParents(buildConfigName, buildConfigDirectory))).default
 
   if (!buildConfig) {
     throw Error(`Invalid BUILD_CONFIG_NAME supplied: ${buildConfigName}`)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
 import { Platform, PLATFORMS } from './constants.js'
+import path from 'path'
+import fs from 'fs'
 
 export const nonNullablePredicate = <T>(value: T): value is NonNullable<T> => value !== null && value !== undefined
 
@@ -16,4 +18,18 @@ export const getPlatformsFromString = (platformsString?: string): Platform[] | u
     )
   }
   return platforms
+}
+
+export const findPathInParents= (name: string, directory: string = '.'): string => {
+  let currentDirectory = process.cwd()
+
+  for (let i = 0; i < 8; i++) {
+    const currentPath = path.resolve(currentDirectory, directory, name)
+    if (fs.existsSync(currentPath)) {
+      return currentPath
+    }
+    currentDirectory = path.resolve(currentDirectory, '..')
+  }
+
+  throw new Error(`${name} not found in ${path.resolve(process.cwd(), directory)} or parent directories!`)
 }

--- a/src/version/program-calc-next-version.ts
+++ b/src/version/program-calc-next-version.ts
@@ -1,11 +1,11 @@
 import { Command } from 'commander'
 import fs from 'fs'
-import path from 'path'
 
 import { VERSION_FILE } from '../constants.js'
+import { findPathInParents } from '../util.js'
 
 const calculateNewVersion = () => {
-  const versionFile = fs.readFileSync(VERSION_FILE, 'utf-8')
+  const versionFile = fs.readFileSync(findPathInParents(VERSION_FILE), 'utf-8')
   // versionCode is just used in the integreat-react-native-app
   const { versionName, versionCode } = JSON.parse(versionFile)
   const versionNameParts = versionName.split('.').map((it: string) => parseInt(it, 10))
@@ -24,7 +24,7 @@ const calculateNewVersion = () => {
 
   return {
     versionName: newVersionName,
-    versionCode: newVersionCode
+    versionCode: newVersionCode,
   }
 }
 


### PR DESCRIPTION
Recursively traverse all parent directories in order to attempt to find the version.json file to allow for execution of scripts from subdirectories. Should be a non-breaking change.