### PR TITLE
Add possibility to use app-toolbelt in external orgs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-toolbelt",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-toolbelt",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@expo/plist": "^0.3.5",
         "@octokit/auth-app": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.7.0",
   "name": "app-toolbelt",
   "description": "Toolbelt for digitalfabrik apps",
   "private": true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,6 @@ export const PLATFORMS: Platform[] = [PLATFORM_ANDROID, PLATFORM_IOS, PLATFORM_W
 export const VERSION_FILE = 'version.json'
 
 export const MAIN_BRANCH = 'main'
+
+// We want any android release to be flagged latest in order to provide an easy way for users to download and install apks
+export const PLATFORMS_FLAGGED_LATEST: Platform[] = [PLATFORM_ANDROID, PLATFORM_NATIVE, PLATFORM_ALL]

--- a/src/github.ts
+++ b/src/github.ts
@@ -48,7 +48,8 @@ type ReleaseInformation = {
   versionName: string
 }
 
-export const versionTagName = ({ platform, versionName }: ReleaseInformation): string => `${versionName}-${platform}`
+export const versionTagName = ({ platform, versionName }: ReleaseInformation): string =>
+  platform === PLATFORM_ALL ? versionName : `${versionName}-${platform}`
 
 const createTag = async (
   tagName: string,
@@ -120,7 +121,8 @@ export const createTags = async (
   await Promise.all(
     platforms.map(platform => {
       const tagName = versionTagName({ versionName, platform })
-      const tagMessage = `[${platform}] ${versionName} - ${versionCode}`
+      const baseTagMessage = `${versionName} (${versionCode})`
+      const tagMessage = platform === PLATFORM_ALL ? baseTagMessage : `[${platform}] ${baseTagMessage}`
       return createTag(tagName, tagMessage, owner, repo, commitSha!, appOctokit)
     }),
   )

--- a/src/github.ts
+++ b/src/github.ts
@@ -5,29 +5,22 @@ import { GithubReleaseOptions } from './release/program-github-release.js'
 import { Command } from 'commander'
 
 export type GithubAuthenticationParams = {
-  deliverinoPrivateKey: string
+  privateKey: string
   owner: string
   repo: string
 }
 
 export const withGithubAuthentication = (command: Command) =>
   command
-    .requiredOption(
-      '--deliverino-private-key <deliverino-private-key>',
-      'Private key of the github app as base64 pem format',
-    )
+    .requiredOption('--private-key <private-key>', 'Private key of the github app as base64 pem format')
     .requiredOption('--owner <owner>', 'Github owner (e.g. "digitalfabrik")')
     .requiredOption('--repo <repo>', 'Github repository')
 
-export const authenticate = async ({
-  deliverinoPrivateKey,
-  owner,
-  repo,
-}: GithubAuthenticationParams): Promise<Octokit> => {
+export const authenticate = async ({ privateKey, owner, repo }: GithubAuthenticationParams): Promise<Octokit> => {
   const appId = 59249 // https://github.com/apps/deliverino
-  const privateKey = Buffer.from(deliverinoPrivateKey, 'base64').toString('ascii')
+  const decodedPrivateKey = Buffer.from(privateKey, 'base64').toString('ascii')
 
-  const octokit = new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey } })
+  const octokit = new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey: decodedPrivateKey } })
   const {
     data: { id: installationId },
   } = await octokit.apps.getRepoInstallation({ owner, repo })

--- a/src/github.ts
+++ b/src/github.ts
@@ -4,10 +4,14 @@ import { Platform, PLATFORMS, PLATFORMS_FLAGGED_LATEST, VERSION_FILE } from './c
 import { GithubReleaseOptions } from './release/program-github-release.js'
 import { Command } from 'commander'
 
+// https://github.com/apps/deliverino
+const DELIVERINO_APP_ID = '59249'
+
 export type GithubAuthenticationParams = {
   privateKey: string
   owner: string
   repo: string
+  githubApp: string
 }
 
 export const withGithubAuthentication = (command: Command) =>
@@ -15,12 +19,20 @@ export const withGithubAuthentication = (command: Command) =>
     .requiredOption('--private-key <private-key>', 'Private key of the github app as base64 pem format')
     .requiredOption('--owner <owner>', 'Github owner (e.g. "digitalfabrik")')
     .requiredOption('--repo <repo>', 'Github repository')
+    .option('--github-app <github-app>', 'Github app id', DELIVERINO_APP_ID)
 
-export const authenticate = async ({ privateKey, owner, repo }: GithubAuthenticationParams): Promise<Octokit> => {
-  const appId = 59249 // https://github.com/apps/deliverino
+export const authenticate = async ({
+  privateKey,
+  owner,
+  repo,
+  githubApp,
+}: GithubAuthenticationParams): Promise<Octokit> => {
   const decodedPrivateKey = Buffer.from(privateKey, 'base64').toString('ascii')
 
-  const octokit = new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey: decodedPrivateKey } })
+  const octokit = new Octokit({
+    authStrategy: createAppAuth,
+    auth: { appId: githubApp, privateKey: decodedPrivateKey },
+  })
   const {
     data: { id: installationId },
   } = await octokit.apps.getRepoInstallation({ owner, repo })

--- a/src/github.ts
+++ b/src/github.ts
@@ -16,7 +16,7 @@ export type GithubAuthenticationParams = {
 
 export const withGithubAuthentication = (command: Command) =>
   command
-    .requiredOption('--private-key <private-key>', 'Private key of the github app as base64 pem format')
+    .requiredOption('--private-key <private-key>', 'Github app private key as base64 pem format')
     .requiredOption('--owner <owner>', 'Github owner (e.g. "digitalfabrik")')
     .requiredOption('--repo <repo>', 'Github repository')
     .option('--github-app <github-app>', 'Github app id', DELIVERINO_APP_ID)

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app'
 import { Octokit } from '@octokit/rest'
-import { Platform, PLATFORMS, PLATFORMS_FLAGGED_LATEST, VERSION_FILE } from './constants.js'
+import { Platform, PLATFORM_ALL, PLATFORMS, PLATFORMS_FLAGGED_LATEST, VERSION_FILE } from './constants.js'
 import { GithubReleaseOptions } from './release/program-github-release.js'
 import { Command } from 'commander'
 
@@ -155,7 +155,8 @@ export const createGithubRelease = async (
   options: GithubReleaseOptions,
 ) => {
   const { owner, repo, productionRelease, releaseNotes } = options
-  const releaseName = `[${platform}] ${newVersionName} - ${newVersionCode}`
+  const baseReleaseName = `${newVersionName} - ${newVersionCode}`
+  const releaseName = platform === PLATFORM_ALL ? baseReleaseName : `[${platform}] ${baseReleaseName}`
   const tagName = versionTagName({ versionName: newVersionName, platform })
 
   const release = await appOctokit.repos.createRelease({

--- a/src/github.ts
+++ b/src/github.ts
@@ -149,7 +149,7 @@ export const createGithubRelease = async (
   appOctokit: Octokit,
   options: GithubReleaseOptions,
 ) => {
-  const { owner, repo, productionRelease, shouldUsePredefinedReleaseNotes, releaseNotes } = options
+  const { owner, repo, productionRelease, releaseNotes } = options
   const releaseName = `[${platform}] ${newVersionName} - ${newVersionCode}`
   const tagName = versionTagName({ versionName: newVersionName, platform })
 
@@ -160,10 +160,7 @@ export const createGithubRelease = async (
     prerelease: !productionRelease,
     make_latest: productionRelease && PLATFORMS_FLAGGED_LATEST.includes(platform) ? 'true' : 'false',
     name: releaseName,
-    body:
-      shouldUsePredefinedReleaseNotes && releaseNotes
-        ? releaseNotes
-        : await generateReleaseNotesFromGithubEndpoint(owner, repo, appOctokit, tagName),
+    body: releaseNotes ?? (await generateReleaseNotesFromGithubEndpoint(owner, repo, appOctokit, tagName)),
   })
   console.log(release.data.id)
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -155,7 +155,7 @@ export const createGithubRelease = async (
   options: GithubReleaseOptions,
 ) => {
   const { owner, repo, productionRelease, releaseNotes } = options
-  const baseReleaseName = `${newVersionName} - ${newVersionCode}`
+  const baseReleaseName = `${newVersionName} (${newVersionCode})`
   const releaseName = platform === PLATFORM_ALL ? baseReleaseName : `[${platform}] ${baseReleaseName}`
   const tagName = versionTagName({ versionName: newVersionName, platform })
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app'
 import { Octokit } from '@octokit/rest'
-import { Platform, PLATFORMS, VERSION_FILE } from './constants.js'
+import { Platform, PLATFORMS, PLATFORMS_FLAGGED_LATEST, VERSION_FILE } from './constants.js'
 import { GithubReleaseOptions } from './release/program-github-release.js'
 import { Command } from 'commander'
 
@@ -158,7 +158,7 @@ export const createGithubRelease = async (
     repo,
     tag_name: tagName,
     prerelease: !productionRelease,
-    make_latest: platform === 'android' ? 'true' : 'false',
+    make_latest: productionRelease && PLATFORMS_FLAGGED_LATEST.includes(platform) ? 'true' : 'false',
     name: releaseName,
     body:
       shouldUsePredefinedReleaseNotes && releaseNotes

--- a/src/release-notes/program-move-to.ts
+++ b/src/release-notes/program-move-to.ts
@@ -8,9 +8,9 @@ type GithubMoveReleaseNotesOptions = GithubAuthenticationParams & {
 
 const moveReleaseNotes = async (
   newVersionName: string,
-  { deliverinoPrivateKey, owner, repo, branch }: GithubMoveReleaseNotesOptions,
+  { privateKey, owner, repo, branch }: GithubMoveReleaseNotesOptions,
 ) => {
-  const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
+  const appOctokit = await authenticate({ privateKey, owner, repo })
   const {
     data: { commit },
   } = await appOctokit.repos.getBranch({ owner, repo, branch })
@@ -104,7 +104,7 @@ export default (parent: Command) => {
     .action(async (newVersionName: string, options: GithubMoveReleaseNotesOptions) => {
       try {
         await moveReleaseNotes(newVersionName, {
-          deliverinoPrivateKey: options.deliverinoPrivateKey,
+          privateKey: options.privateKey,
           branch: options.branch,
           owner: options.owner,
           repo: options.repo,

--- a/src/release-notes/program-move-to.ts
+++ b/src/release-notes/program-move-to.ts
@@ -6,11 +6,9 @@ type GithubMoveReleaseNotesOptions = GithubAuthenticationParams & {
   branch: string
 }
 
-const moveReleaseNotes = async (
-  newVersionName: string,
-  { privateKey, owner, repo, branch }: GithubMoveReleaseNotesOptions,
-) => {
-  const appOctokit = await authenticate({ privateKey, owner, repo })
+const moveReleaseNotes = async (newVersionName: string, options: GithubMoveReleaseNotesOptions) => {
+  const { owner, repo, branch } = options
+  const appOctokit = await authenticate(options)
   const {
     data: { commit },
   } = await appOctokit.repos.getBranch({ owner, repo, branch })
@@ -103,12 +101,7 @@ export default (parent: Command) => {
     .requiredOption('--branch <branch>', 'the current branch')
     .action(async (newVersionName: string, options: GithubMoveReleaseNotesOptions) => {
       try {
-        await moveReleaseNotes(newVersionName, {
-          privateKey: options.privateKey,
-          branch: options.branch,
-          owner: options.owner,
-          repo: options.repo,
-        })
+        await moveReleaseNotes(newVersionName, options)
       } catch (e) {
         console.error(e)
         process.exit(1)

--- a/src/release/program-github-promote-release.ts
+++ b/src/release/program-github-promote-release.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander'
 import { authenticate, GithubAuthenticationParams, withGithubAuthentication } from '../github.js'
-import { Platform } from '../constants.js'
+import { Platform, PLATFORMS_FLAGGED_LATEST } from '../constants.js'
 
 type GithubPromoteReleaseOptions = GithubAuthenticationParams & {
   platform: Platform
@@ -19,9 +19,6 @@ const getReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: Gith
 const promoteReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: GithubPromoteReleaseOptions) => {
   const releases = await getReleases({ deliverinoPrivateKey, owner, repo, platform })
   const preReleases = releases.filter(release => release.prerelease)
-  // For integreat we always want platform android to be the latest release, so a link to the latest github release will go to the apk
-  // For entitlementcard and lunes we always want platform all to be the lastest release
-  const platformsFlaggedLatest = ['android', 'native', 'all']
   const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
   await Promise.all(
     preReleases.map(async preRelease => {
@@ -30,7 +27,7 @@ const promoteReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: 
         repo,
         release_id: preRelease.id,
         prerelease: false,
-        make_latest: platformsFlaggedLatest.includes(platform) ? 'true' : 'false',
+        make_latest: PLATFORMS_FLAGGED_LATEST.includes(platform) ? 'true' : 'false',
       })
       console.warn(`Release ${preRelease.tag_name} promoted with status:`, result.status)
     }),

--- a/src/release/program-github-promote-release.ts
+++ b/src/release/program-github-promote-release.ts
@@ -6,8 +6,9 @@ type GithubPromoteReleaseOptions = GithubAuthenticationParams & {
   platform: Platform
 }
 
-const getReleases = async ({ privateKey, owner, repo, platform }: GithubPromoteReleaseOptions) => {
-  const appOctokit = await authenticate({ privateKey, owner, repo })
+const getReleases = async (options: GithubPromoteReleaseOptions) => {
+  const appOctokit = await authenticate(options)
+  const { owner, repo, platform } = options
 
   const releases = await appOctokit.rest.repos.listReleases({
     owner,
@@ -16,10 +17,11 @@ const getReleases = async ({ privateKey, owner, repo, platform }: GithubPromoteR
   return releases.data.filter(release => release.tag_name.includes(platform))
 }
 
-const promoteReleases = async ({ privateKey, owner, repo, platform }: GithubPromoteReleaseOptions) => {
-  const releases = await getReleases({ privateKey, owner, repo, platform })
+const promoteReleases = async (options: GithubPromoteReleaseOptions) => {
+  const { owner, repo, platform } = options
+  const releases = await getReleases(options)
   const preReleases = releases.filter(release => release.prerelease)
-  const appOctokit = await authenticate({ privateKey, owner, repo })
+  const appOctokit = await authenticate(options)
   await Promise.all(
     preReleases.map(async preRelease => {
       const result = await appOctokit.rest.repos.updateRelease({

--- a/src/release/program-github-promote-release.ts
+++ b/src/release/program-github-promote-release.ts
@@ -6,8 +6,8 @@ type GithubPromoteReleaseOptions = GithubAuthenticationParams & {
   platform: Platform
 }
 
-const getReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: GithubPromoteReleaseOptions) => {
-  const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
+const getReleases = async ({ privateKey, owner, repo, platform }: GithubPromoteReleaseOptions) => {
+  const appOctokit = await authenticate({ privateKey, owner, repo })
 
   const releases = await appOctokit.rest.repos.listReleases({
     owner,
@@ -16,10 +16,10 @@ const getReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: Gith
   return releases.data.filter(release => release.tag_name.includes(platform))
 }
 
-const promoteReleases = async ({ deliverinoPrivateKey, owner, repo, platform }: GithubPromoteReleaseOptions) => {
-  const releases = await getReleases({ deliverinoPrivateKey, owner, repo, platform })
+const promoteReleases = async ({ privateKey, owner, repo, platform }: GithubPromoteReleaseOptions) => {
+  const releases = await getReleases({ privateKey, owner, repo, platform })
   const preReleases = releases.filter(release => release.prerelease)
-  const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
+  const appOctokit = await authenticate({ privateKey, owner, repo })
   await Promise.all(
     preReleases.map(async preRelease => {
       const result = await appOctokit.rest.repos.updateRelease({

--- a/src/release/program-github-release-assets.ts
+++ b/src/release/program-github-release-assets.ts
@@ -7,13 +7,13 @@ type GithubUploadAssetsOptions = GithubAuthenticationParams & {
   files: string
 }
 
-const uploadAssets = async ({ deliverinoPrivateKey, owner, repo, releaseId, files }: GithubUploadAssetsOptions) => {
+const uploadAssets = async ({ privateKey, owner, repo, releaseId, files }: GithubUploadAssetsOptions) => {
   if (!files) {
     console.log('No files to upload. Skipping.')
     return
   }
 
-  const appOctokit = await authenticate({ deliverinoPrivateKey, owner, repo })
+  const appOctokit = await authenticate({ privateKey, owner, repo })
 
   await Promise.all(
     files

--- a/src/release/program-github-release-assets.ts
+++ b/src/release/program-github-release-assets.ts
@@ -7,13 +7,14 @@ type GithubUploadAssetsOptions = GithubAuthenticationParams & {
   files: string
 }
 
-const uploadAssets = async ({ privateKey, owner, repo, releaseId, files }: GithubUploadAssetsOptions) => {
+const uploadAssets = async (options: GithubUploadAssetsOptions) => {
+  const { files, releaseId, owner, repo } = options
   if (!files) {
     console.log('No files to upload. Skipping.')
     return
   }
 
-  const appOctokit = await authenticate({ privateKey, owner, repo })
+  const appOctokit = await authenticate(options)
 
   await Promise.all(
     files

--- a/src/release/program-github-release.ts
+++ b/src/release/program-github-release.ts
@@ -11,11 +11,8 @@ export default (parent: Command) => {
   const command = parent
     .description('creates a new release for the specified platform')
     .command('create <platform> <new-version-name> <new-version-code>')
-    .option('--production-release', 'whether this is a production release or not. If unset false', false)
-    .option(
-      '--release-notes <release-notes>',
-      'the release notes (for the selected platform) as JSON string. If not defined the release notes will be generated',
-    )
+    .option('--production-release', 'Whether this is a production or a pre-release.', false)
+    .option('--release-notes <release-notes>', 'The release notes as JSON string, will be auto-generated otherwise.')
     .action(
       async (platform: Platform, newVersionName: string, newVersionCode: string, options: GithubReleaseOptions) => {
         try {

--- a/src/release/program-github-release.ts
+++ b/src/release/program-github-release.ts
@@ -4,7 +4,6 @@ import { Platform } from '../constants.js'
 
 export type GithubReleaseOptions = GithubAuthenticationParams & {
   productionRelease: boolean
-  shouldUsePredefinedReleaseNotes: boolean
   releaseNotes?: string
 }
 
@@ -13,11 +12,6 @@ export default (parent: Command) => {
     .description('creates a new release for the specified platform')
     .command('create <platform> <new-version-name> <new-version-code>')
     .option('--production-release', 'whether this is a production release or not. If unset false', false)
-    .option(
-      '--should-use-predefined-release-notes',
-      'whether predefined release notes should be used or not. Release notes have to be passed if set. If unset false',
-      false,
-    )
     .option(
       '--release-notes <release-notes>',
       'the release notes (for the selected platform) as JSON string. If not defined the release notes will be generated',


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
It is currently not possible to use the app-toolbelt in orgs other than `digitalfabrik` due to the restriction to the github app `deliverino`.
This PR adds support to use any github app and does some other adjustments allowing for more general uses.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- [BREAKING] Rename `--deliverino-private-key` to `--private-key`
- [BREAKING] Release and tag names only include the platform if not `all` (e.g. `2025.8.1 (123456)` instead of `[all] 2025.8.1 - 123456` and `2025.8.1` instead of `2025.8.1-all`)
- [BREAKING] Version codes are now in parentheses in release names and tag messages (e.g. `2025.8.1 (123456)` instead of `2025.8.1 - 123456`)
- [BREAKING] Also tag `native` and `all` production releases as latest
- [BREAKING] Remove redundant parameter `--should-use-predefined-release-notes` (passing `--release-notes` is now enough)
- Add option `--github-app` to override the github app (default is still deliverino)
- Add option `--tag-only` to `bump-to` script to tag the latest commit instead of updating the version in `version.json`
- Bump version to `0.7.0`

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A