### PR TITLE
48: Remove platform information from tag

### DIFF
--- a/src/release/program-git-release.ts
+++ b/src/release/program-git-release.ts
@@ -2,14 +2,12 @@ import { Command } from 'commander'
 import {
   authenticate,
   commitVersion,
-  createTags,
+  createTag,
   GithubAuthenticationParams,
   withGithubAuthentication,
 } from '../github.js'
-import { getPlatformsFromString } from '../util.js'
 
 type GithubBumpVersionOptions = GithubAuthenticationParams & {
-  platforms?: string
   branch: string
   tagOnly: boolean
 }
@@ -19,10 +17,6 @@ export default (parent: Command) => {
     .description('Bump and tag the latest version')
     .command('bump-to <new-version-name> <new-version-code>')
     .requiredOption('--branch <branch>', 'the current branch')
-    .option(
-      '--platforms <platforms>',
-      'define the platforms separated by slash for the tags f.e. "native/web". If unset tags for all platforms will be created',
-    )
     .option('--tag-only', 'Only tag the latest commit instead of bumping the version.', false)
     .action(async (newVersionName, newVersionCode, options: GithubBumpVersionOptions) => {
       try {
@@ -41,10 +35,8 @@ export default (parent: Command) => {
         if (!commitSha) {
           throw new Error(`Failed to commit!`)
         }
-
-        const platforms = getPlatformsFromString(options.platforms)
-
-        await createTags(newVersionName, versionCode, commitSha, owner, repo, appOctokit, platforms)
+        const tagMessage = `${newVersionName} (${versionCode})`
+        await createTag(newVersionName, tagMessage, owner, repo, commitSha, appOctokit)
       } catch (e) {
         console.error(e)
         process.exit(1)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,24 +1,7 @@
-import { Platform, PLATFORMS } from './constants.js'
 import path from 'path'
 import fs from 'fs'
 
 export const nonNullablePredicate = <T>(value: T): value is NonNullable<T> => value !== null && value !== undefined
-
-export const getPlatformsFromString = (platformsString?: string): Platform[] | undefined => {
-  if (!platformsString) {
-    return undefined
-  }
-  const delimiter = '/'
-  const platforms = platformsString.split(delimiter) as Platform[]
-  if (!platforms.every((platform: Platform) => PLATFORMS.includes(platform))) {
-    throw new Error(
-      `Provided platforms are incorrect! Please check available platforms (${PLATFORMS.join(
-        ',',
-      )}) and correct delimiter (${delimiter})`,
-    )
-  }
-  return platforms
-}
 
 export const findPathInParents = (name: string, directory: string = '.'): string => {
   let currentDirectory = process.cwd()


### PR DESCRIPTION
### Short Description

See issue description

### Proposed Changes

<!-- Describe this PR in more detail. -->

- remove platform option for create Tag, 
- remove createTags function

### Breaking Changes

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- bump-to does not accept option `platform` anymore. We decided to only create tags without platform information to ensure that github can automatically reference the previous tag and create proper release notes.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #48 