### PR TITLE
promote: Fix `mark_latest` flag with multiple pre-releases

### DIFF
--- a/src/release/program-github-promote-release.ts
+++ b/src/release/program-github-promote-release.ts
@@ -27,13 +27,14 @@ const promoteReleases = async (options: GithubAuthenticationParams) => {
   const preReleases = releases.filter(release => release.prerelease)
   const appOctokit = await authenticate(options)
   await Promise.all(
-    preReleases.map(async preRelease => {
+    preReleases.map(async (preRelease, index) => {
+      const isLatest = index === 0
       const result = await appOctokit.rest.repos.updateRelease({
         owner,
         repo,
         release_id: preRelease.id,
         prerelease: false,
-        make_latest: 'true',
+        make_latest: isLatest ? 'true' : 'false',
       })
       console.warn(`Release ${preRelease.tag_name} promoted with status:`, result.status)
     }),


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
If there have been multiple pre-releases before a promote, `getReleases` will return them all in chronological order. Later, they will all be marked as latest, causing the last write to win. This is often the oldest pre-release in practice.

This pr fixes the behavior so that only the latest (first) pre-release will be marked as latest.

This has been an issue for the current lunes release, where the oldest of the pre-releases was marked as latest, instead of the latest pre-relase. See [this](https://app.circleci.com/pipelines/github/digitalfabrik/lunes-app/4525/workflows/022b81c1-8fc0-42a0-8837-84655bbad69c/jobs/13703/parallel-runs/0/steps/0-105) workflow.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Only set the `mark_latest` flag for the first pre-release

### Breaking Changes

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
Technically breaking, but I don't think anybody relies on this behavior (?)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A