### PR TITLE
68: Generate sbom

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -17,6 +17,7 @@ import notify from './notify/notify.js'
 import packageJson from '../package.json' with { type: 'json' }
 import notifyGithub from './notify/notifyGithub.js'
 import openPr from './pr/program-open-pr.js'
+import generateSbom from './sbom/generate-sbom.js'
 
 const buildCommand = (
   exitOverride?: (err: CommanderError) => never | void,
@@ -63,6 +64,9 @@ const buildCommand = (
 
   const prCommand = v0.command('pr')
   openPr(prCommand)
+
+  const generateCommand = v0.command('generate')
+  generateSbom(generateCommand)
 
   return root
 }

--- a/src/sbom/generate-sbom.ts
+++ b/src/sbom/generate-sbom.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander'
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { authenticate, GithubAuthenticationParams, withGithubAuthentication } from '../github.js'
+
+type CommitSbomOptions = GithubAuthenticationParams & {
+  repoPath: string
+  branch: string
+  versionName: string
+  sourceName: string
+}
+
+export default (parent: Command) => {
+  const command = parent
+    .description('Generate an SBOM using syft and commit it to the repository')
+    .command('sbom')
+    .requiredOption('--repo-path <repo-path>', 'Path where the SBOM file will be stored in the repository')
+    .requiredOption('--branch <branch>', 'The branch to commit the SBOM to')
+    .requiredOption('--version-name <version-name>', 'The version name for the commit message')
+    .requiredOption('--source-name <source-name>', 'The source name for the SBOM (SYFT_SOURCE_NAME)')
+    .action(async (options: CommitSbomOptions) => {
+      try {
+        const { repoPath, branch, versionName, sourceName, owner, repo } = options
+
+        const tmpFile = path.join(os.tmpdir(), 'manifest.spdx.json')
+        const env = {
+          ...process.env,
+          SYFT_SOURCE_VERSION: versionName,
+          SYFT_SOURCE_NAME: sourceName,
+          SYFT_FORMAT_SPDX_JSON_PRETTY: 'true',
+        }
+
+        console.log(`Generating SBOM for ${sourceName}@${versionName}`)
+        execSync(`syft scan . -o spdx-json=${tmpFile}`, { env, stdio: 'inherit' })
+
+        const appOctokit = await authenticate(options)
+
+        const contentBase64 = fs.readFileSync(tmpFile).toString('base64')
+
+        let sha: string | undefined
+        try {
+          const existing = await appOctokit.repos.getContent({ owner, repo, path: repoPath, ref: branch })
+          if (!Array.isArray(existing.data)) {
+            sha = existing.data.sha
+          }
+        } catch (e) {
+          console.error(e)
+        }
+
+        await appOctokit.repos.createOrUpdateFileContents({
+          owner,
+          repo,
+          path: repoPath,
+          branch,
+          message: `Add SBOM for ${versionName}\n[skip ci]`,
+          content: contentBase64,
+          ...(sha ? { sha } : {}),
+        })
+
+        console.log(`SBOM committed to ${repoPath} on ${branch}`)
+      } catch (e) {
+        console.error(e)
+        process.exit(1)
+      }
+    })
+  return withGithubAuthentication(command)
+}

--- a/src/sbom/generate-sbom.ts
+++ b/src/sbom/generate-sbom.ts
@@ -11,8 +11,13 @@ const ensureSyftInstalled = () => {
   try {
     execSync('syft version', { stdio: 'ignore' })
   } catch {
+    if (!process.env['CI']) {
+      throw new Error(
+        'syft is not installed or not in PATH. Please install it manually, e.g. via brew install syft or mise use syft.',
+      )
+    }
     console.log('syft not found, installing...')
-    execSync('curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin', { stdio: 'inherit' })
+    execSync('curl -sSfL https://get.anchore.io/syft | sh -s -- -b /usr/local/bin', { stdio: 'inherit' })
   }
 }
 
@@ -57,7 +62,7 @@ export default (parent: Command) => {
         process.exit(1)
       }
       if (!releaseId && !path) {
-        console.error('Either --release-id or both --path and --branch must be provided.')
+        console.error('Either --release-id or each of --path, --branch and --version-name must be provided.')
         process.exit(1)
       }
 

--- a/src/sbom/generate-sbom.ts
+++ b/src/sbom/generate-sbom.ts
@@ -6,25 +6,36 @@ import path from 'node:path'
 import { authenticate, GithubAuthenticationParams, withGithubAuthentication } from '../github.js'
 
 type CommitSbomOptions = GithubAuthenticationParams & {
-  repoPath: string
-  branch: string
+  repoPath?: string
+  branch?: string
   versionName: string
   sourceName: string
+  releaseId?: number
 }
 
 export default (parent: Command) => {
   const command = parent
-    .description('Generate an SBOM using syft and commit it to the repository')
+    .description('Generate an SBOM using syft and commit it to the repository or/and uploads it to a GitHub release')
     .command('sbom')
-    .requiredOption('--repo-path <repo-path>', 'Path where the SBOM file will be stored in the repository')
-    .requiredOption('--branch <branch>', 'The branch to commit the SBOM to')
     .requiredOption('--version-name <version-name>', 'The version name for the commit message')
     .requiredOption('--source-name <source-name>', 'The source name for the SBOM (SYFT_SOURCE_NAME)')
+    .option(
+      '--repo-path <repo-path>',
+      'Path with filename where the SBOM file will be stored in the repository. If omitted, the SBOM will not be committed.',
+    )
+    .option('--branch <branch>', 'The branch to commit the SBOM to. Required when --repo-path is set.')
+    .option('--release-id <release-id>', 'If provided, the SBOM will also be uploaded to this GitHub release.')
     .action(async (options: CommitSbomOptions) => {
-      try {
-        const { repoPath, branch, versionName, sourceName, owner, repo } = options
+      const { repoPath, branch, versionName, sourceName, releaseId, owner, repo } = options
 
-        const tmpFile = path.join(os.tmpdir(), 'manifest.spdx.json')
+      if (!releaseId && !repoPath && !branch) {
+        console.log('Either --release-id or --repo-path and --branch must be set.')
+        return
+      }
+
+      try {
+        const fileName = repoPath ? path.basename(repoPath) : 'manifest.spdx.json'
+        const tmpFile = path.join(os.tmpdir(), fileName)
         const env = {
           ...process.env,
           SYFT_SOURCE_VERSION: versionName,
@@ -44,29 +55,43 @@ export default (parent: Command) => {
 
         const appOctokit = await authenticate(options)
 
-        const contentBase64 = fs.readFileSync(tmpFile).toString('base64')
+        if (repoPath && branch) {
+          const contentBase64 = fs.readFileSync(tmpFile).toString('base64')
 
-        let sha: string | undefined
-        try {
-          const existing = await appOctokit.repos.getContent({ owner, repo, path: repoPath, ref: branch })
-          if (!Array.isArray(existing.data)) {
-            sha = existing.data.sha
+          let sha: string | undefined
+          try {
+            const existing = await appOctokit.repos.getContent({ owner, repo, path: repoPath, ref: branch })
+            if (!Array.isArray(existing.data)) {
+              sha = existing.data.sha
+            }
+          } catch (e) {
+            console.error(e)
           }
-        } catch (e) {
-          console.error(e)
+
+          await appOctokit.repos.createOrUpdateFileContents({
+            owner,
+            repo,
+            path: repoPath,
+            branch,
+            message: `Add SBOM for ${versionName}\n[skip ci]`,
+            content: contentBase64,
+            ...(sha ? { sha } : {}),
+          })
+
+          console.log(`SBOM committed to ${repoPath} on ${branch}`)
         }
 
-        await appOctokit.repos.createOrUpdateFileContents({
-          owner,
-          repo,
-          path: repoPath,
-          branch,
-          message: `Add SBOM for ${versionName}\n[skip ci]`,
-          content: contentBase64,
-          ...(sha ? { sha } : {}),
-        })
-
-        console.log(`SBOM committed to ${repoPath} on ${branch}`)
+        if (releaseId) {
+          const fileData = fs.readFileSync(tmpFile)
+          await appOctokit.rest.repos.uploadReleaseAsset({
+            owner,
+            repo,
+            release_id: releaseId,
+            name: 'manifest.spdx.json',
+            data: fileData as unknown as string,
+          })
+          console.log('SBOM uploaded to release')
+        }
       } catch (e) {
         console.error(e)
         process.exit(1)

--- a/src/sbom/generate-sbom.ts
+++ b/src/sbom/generate-sbom.ts
@@ -32,6 +32,13 @@ export default (parent: Command) => {
           SYFT_FORMAT_SPDX_JSON_PRETTY: 'true',
         }
 
+        try {
+          execSync('syft version', { stdio: 'ignore' })
+        } catch {
+          console.log('syft not found, installing...')
+          execSync('curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin', { stdio: 'inherit' })
+        }
+
         console.log(`Generating SBOM for ${sourceName}@${versionName}`)
         execSync(`syft scan . -o spdx-json=${tmpFile}`, { env, stdio: 'inherit' })
 

--- a/src/sbom/generate-sbom.ts
+++ b/src/sbom/generate-sbom.ts
@@ -2,65 +2,77 @@ import { Command } from 'commander'
 import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
-import path from 'node:path'
+import nodePath from 'node:path'
 import { authenticate, GithubAuthenticationParams, withGithubAuthentication } from '../github.js'
 
-type CommitSbomOptions = GithubAuthenticationParams & {
-  repoPath?: string
+const SBOM_ASSET_NAME = 'manifest.spdx.json'
+
+const ensureSyftInstalled = () => {
+  try {
+    execSync('syft version', { stdio: 'ignore' })
+  } catch {
+    console.log('syft not found, installing...')
+    execSync('curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin', { stdio: 'inherit' })
+  }
+}
+
+const generateSbomFile = (sourceName: string, versionName: string): string => {
+  const tmpFile = nodePath.join(os.tmpdir(), SBOM_ASSET_NAME)
+  console.log(`Generating SBOM for ${sourceName}@${versionName}`)
+  execSync(`syft scan . -o spdx-json=${tmpFile}`, {
+    env: {
+      ...process.env,
+      SYFT_SOURCE_VERSION: versionName,
+      SYFT_SOURCE_NAME: sourceName,
+      SYFT_FORMAT_SPDX_JSON_PRETTY: 'true',
+    },
+    stdio: 'inherit',
+  })
+  return tmpFile
+}
+
+type GenerateSbomOptions = GithubAuthenticationParams & {
+  path?: string
   branch?: string
-  versionName: string
-  sourceName: string
+  versionName?: string
   releaseId?: number
 }
 
 export default (parent: Command) => {
   const command = parent
-    .description('Generate an SBOM using syft and commit it to the repository or/and uploads it to a GitHub release')
     .command('sbom')
-    .requiredOption('--version-name <version-name>', 'The version name for the commit message')
-    .requiredOption('--source-name <source-name>', 'The source name for the SBOM (SYFT_SOURCE_NAME)')
+    .description('Generate an SBOM using syft and commit it to the repository and/or upload it to a GitHub release')
+    .option('--version-name <version-name>', 'The version name for the commit message')
     .option(
-      '--repo-path <repo-path>',
+      '--path <path>',
       'Path with filename where the SBOM file will be stored in the repository. If omitted, the SBOM will not be committed.',
     )
     .option('--branch <branch>', 'The branch to commit the SBOM to. Required when --repo-path is set.')
     .option('--release-id <release-id>', 'If provided, the SBOM will also be uploaded to this GitHub release.')
-    .action(async (options: CommitSbomOptions) => {
-      const { repoPath, branch, versionName, sourceName, releaseId, owner, repo } = options
+    .action(async (options: GenerateSbomOptions) => {
+      const { path, branch, versionName, releaseId, owner, repo } = options
 
-      if (!releaseId && !repoPath && !branch) {
-        console.log('Either --release-id or --repo-path and --branch must be set.')
-        return
+      if (Boolean(path) !== Boolean(branch) || Boolean(path) !== Boolean(versionName)) {
+        console.error('--path, --branch and --version-name must be set together.')
+        process.exit(1)
+      }
+      if (!releaseId && !path) {
+        console.error('Either --release-id or both --path and --branch must be provided.')
+        process.exit(1)
       }
 
       try {
-        const fileName = repoPath ? path.basename(repoPath) : 'manifest.spdx.json'
-        const tmpFile = path.join(os.tmpdir(), fileName)
-        const env = {
-          ...process.env,
-          SYFT_SOURCE_VERSION: versionName,
-          SYFT_SOURCE_NAME: sourceName,
-          SYFT_FORMAT_SPDX_JSON_PRETTY: 'true',
-        }
-
-        try {
-          execSync('syft version', { stdio: 'ignore' })
-        } catch {
-          console.log('syft not found, installing...')
-          execSync('curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin', { stdio: 'inherit' })
-        }
-
-        console.log(`Generating SBOM for ${sourceName}@${versionName}`)
-        execSync(`syft scan . -o spdx-json=${tmpFile}`, { env, stdio: 'inherit' })
+        ensureSyftInstalled()
+        const tmpFile = generateSbomFile(repo, versionName!)
 
         const appOctokit = await authenticate(options)
 
-        if (repoPath && branch) {
+        if (path && branch) {
           const contentBase64 = fs.readFileSync(tmpFile).toString('base64')
 
           let sha: string | undefined
           try {
-            const existing = await appOctokit.repos.getContent({ owner, repo, path: repoPath, ref: branch })
+            const existing = await appOctokit.repos.getContent({ owner, repo, path: path, ref: branch })
             if (!Array.isArray(existing.data)) {
               sha = existing.data.sha
             }
@@ -71,14 +83,14 @@ export default (parent: Command) => {
           await appOctokit.repos.createOrUpdateFileContents({
             owner,
             repo,
-            path: repoPath,
+            path,
             branch,
             message: `Add SBOM for ${versionName}\n[skip ci]`,
             content: contentBase64,
             ...(sha ? { sha } : {}),
           })
 
-          console.log(`SBOM committed to ${repoPath} on ${branch}`)
+          console.log(`SBOM committed to ${path} on ${branch}`)
         }
 
         if (releaseId) {
@@ -88,7 +100,7 @@ export default (parent: Command) => {
             repo,
             release_id: releaseId,
             name: 'manifest.spdx.json',
-            data: fileData as unknown as string,
+            data: fileData.toString(),
           })
           console.log('SBOM uploaded to release')
         }

--- a/src/sbom/generate-sbom.ts
+++ b/src/sbom/generate-sbom.ts
@@ -99,7 +99,7 @@ export default (parent: Command) => {
             owner,
             repo,
             release_id: releaseId,
-            name: 'manifest.spdx.json',
+            name: 'sbom.spdx.json',
             data: fileData.toString(),
           })
           console.log('SBOM uploaded to release')

--- a/test/__snapshots__/v0.test.ts.snap
+++ b/test/__snapshots__/v0.test.ts.snap
@@ -12,6 +12,6 @@ exports[`stability test release-notes 1`] = `"Usage: whitelabel v0 release-notes
 
 exports[`stability test sentry 1`] = `"Usage: whitelabel v0 sentry [options] [command] Options: -h, --help display help for command Commands: create [options] <package-name> <version-name> <sourcemap-directory> create a new release on sentry. This file uses the configuration from ./.sentryclirc help [command] display help for command"`;
 
-exports[`stability test v0 1`] = `"Usage: whitelabel v0 [options] [command] Options: -h, --help display help for command Commands: release-notes version Manage version build-config release sentry notify pr help [command] display help for command"`;
+exports[`stability test v0 1`] = `"Usage: whitelabel v0 [options] [command] Options: -h, --help display help for command Commands: release-notes version Manage version build-config release sentry notify pr generate help [command] display help for command"`;
 
 exports[`stability test version 1`] = `"Usage: whitelabel v0 version [options] [command] Manage version Options: -h, --help display help for command Commands: calc calculate the next version help [command] display help for command"`;


### PR DESCRIPTION
### Short Description
If we want to generate SBOM in any project, we can use the app-toolbelt for it

### Proposed Changes

- add command to generate sbom json.
- sbom can be added to github release by providing `--releaseId`
- sbom can be commited to the repo by providing `branch` and `repo-path`
### Breaking Changes

No

### Example command
```
        npx --no app-toolbelt v0 generate sbom \
          --version-name "${NEW_VERSION}" \
          --releaseId "${RELEASE_ID}" \
          --path lunes_cms/_manifest/spdx_2.2/manifest.spdx.json \
          --branch "${CIRCLE_BRANCH}" \
          --private-key "${DELIVERINO_PRIVATE_KEY}" \
          --owner "${CIRCLE_PROJECT_USERNAME}" \
          --repo "${CIRCLE_PROJECT_REPONAME}"
```

### Testing
You won't be able to push the sbom file to a repo without deliverino setup (app-toolbelt local)
i ran it here:
https://app.circleci.com/pipelines/github/digitalfabrik/lunes-cms/2133/workflows/746a9040-1b42-4eb0-9a77-50df0e2a76e1

and the file is there
https://github.com/digitalfabrik/lunes-cms/blob/sbom-test/lunes_cms/_manifest/spdx_2.2/manifest.spdx.json

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #68