### PR TITLE
79: Compile app toolbelt in prepack script

### DIFF
--- a/bin/app-toolbelt
+++ b/bin/app-toolbelt
@@ -1,3 +1,0 @@
-#!/usr/bin/env -S npx tsx
-
-import "../src/start.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "typescript": "^6.0.3"
       },
       "bin": {
-        "app-toolbelt": "bin/app-toolbelt"
+        "app-toolbelt": "dist/start.js"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:updateSnapshot": "NODE_OPTIONS='--experimental-vm-modules' jest test/v0.test.ts -u",
     "prettier:check": "prettier --check .",
-    "prettier:fix": "prettier --write ."
+    "prettier:fix": "prettier --write .",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@expo/plist": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "bin": {
-    "app-toolbelt": "bin/app-toolbelt"
+    "app-toolbelt": "dist/start.js"
   },
   "scripts": {
     "build": "tsc --build",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "prettier:fix": "prettier --write .",
     "prepack": "npm run build"
   },
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@expo/plist": "^0.5.2",
     "@octokit/auth-app": "^8.2.0",


### PR DESCRIPTION
### Short Description

Runs the `build` script before packaging and executes the compiled script rather than shimming it with `tsx`.

### Proposed Changes

- Compile source to `/dist`.
- Run the `app-toolbelt` directly with node.

### Breaking Changes

- Projects using npm: this works automatically (npm  runs `prepack` script automatically for git installed dependencies).
- Projects using yarn: this should work automatically (yarn runs `prepack` script automatically for git installed dependencies).
- Projects using pnpm need (in `pnpm-workspace.yaml`):
  ```yaml
  allowBuilds:
    app-toolbelt: true
  ```

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #79